### PR TITLE
Add tag support to ecs-service

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,82 @@
+# Some of this logic was stolen from https://www.freecodecamp.org/news/a-lightweight-tool-agnostic-ci-cd-flow-with-github-actions/
+
+name: terraform
+
+on:
+  push:
+#   branches:
+#     - master
+  pull_request:
+
+jobs:
+  terraform:
+    name: terraform
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: terraform setup
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 0.12.29
+      #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+
+#     TODO: This step duplicates work done by the Makefile.
+#     - name: check terraform formatting
+#       id: fmt
+#       run: |
+#         terraform fmt -check -recursive
+
+      - name: run make
+      # env:
+      #   TOKEN: ${{ secrets.TOKEN }}
+        run: |
+          make all
+
+#     - name: terraform init
+#       id: init
+#       run: terraform init
+#
+#      - name: terraform plan
+#        id: plan
+#        if: github.event_name == 'pull_request'
+#        run: terraform plan -no-color
+#        continue-on-error: true
+#
+#      - uses: actions/github-script@0.9.0
+#        if: github.event_name == 'pull_request'
+#        env:
+#          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+#        with:
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          script: |
+#            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+#            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+#            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+#
+#            <details><summary>Show Plan</summary>
+#
+#            \`\`\`${process.env.PLAN}\`\`\`
+#
+#            </details>
+#
+#            *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+#
+#              
+#            github.issues.createComment({
+#              issue_number: context.issue.number,
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              body: output
+#            })
+#
+#      - name: terraform plan status
+#        if: steps.plan.outcome == 'failure'
+#        run: exit 1
+#
+#      - name: terraform apply
+#        if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+#        run: terraform apply -auto-approve

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform
+FROM hashicorp/terraform:0.12
 
 RUN apk add make
 

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test:
 	# Do NOT define a variable in files other than variables.tf
 	! $(EGREP) 'variable\s+"\w+"\s*\{' $(SRCS) --exclude=variables.tf
 	# DO put a badge in top-level README.md
-	grep -q "\[\!\[Build Status\]([^)]*$(REPO)/status.svg)\]([^)]*$(REPO))" README.md
+	grep -q "\[\!\[Terraform actions status\]([^)]*$(REPO)/workflows/terraform/badge.svg)\]([^)]*$(REPO)/actions)" README.md
 	# Do NOT split a source line over more than one line
 	! $(GREP) 'source\s*=\s*$$' $(SRCS) $(DOCS)
 	# Do NOT use ?ref= in source lines in a README.md!

--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ that points to the load balancer. Requires that a `load_balancer` block is defin
 
 * `autoscale` – (Optional) An [autoscale](#autoscale) block used to create an autoscaling configuration. Requires that a `autoscale` block is defined. Learn more about [ECS autoscaling](https://docs.aws.amazon.com/autoscaling/application/userguide/application-auto-scaling-step-scaling-policies.html).
 
+* `tags` - Tags to be applied to resources where supported.
+
 `autoscale`
 ----------
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ecs-service
 
-[![Build Status](https://drone.techservices.illinois.edu/api/badges/techservicesillinois/terraform-aws-ecs-service/status.svg)](https://drone.techservices.illinois.edu/techservicesillinois/terraform-aws-ecs-service)
+[![Terraform actions status](https://github.com/techservicesillinois/terraform-aws-ecs-service/workflows/terraform/badge.svg)](https://github.com/techservicesillinois/terraform-aws-ecs-service/actions)
 
 Provides an ECS service - effectively a task that is expected to
 run until an error occurs or a user terminates it (typically a

--- a/main.tf
+++ b/main.tf
@@ -62,6 +62,8 @@ resource "aws_ecs_service" "awsvpc_all" {
       0,
     )
   }
+
+  tags = merge({ "Name" = var.name }, var.tags)
 }
 
 # This resource is conditionally built when using awsvpc network mode
@@ -109,6 +111,8 @@ resource "aws_ecs_service" "awsvpc_lb" {
     security_groups  = local.security_groups
     subnets          = local.all_subnets
   }
+
+  tags = merge({ "Name" = var.name }, var.tags)
 }
 
 # This resource is conditionally built when using awsvpc network mode
@@ -162,6 +166,8 @@ resource "aws_ecs_service" "awsvpc_sd" {
       0,
     )
   }
+
+  tags = merge({ "Name" = var.name }, var.tags)
 }
 
 # This resource is conditionally built when using awsvpc network
@@ -203,6 +209,8 @@ resource "aws_ecs_service" "awsvpc" {
     security_groups  = local.security_groups
     subnets          = local.all_subnets
   }
+
+  tags = merge({ "Name" = var.name }, var.tags)
 }
 
 # This resource is conditionally built when not using awsvpc network
@@ -257,6 +265,8 @@ resource "aws_ecs_service" "all" {
       0,
     )
   }
+
+  tags = merge({ "Name" = var.name }, var.tags)
 }
 
 # This resource is conditionally built when not using awsvpc network
@@ -299,6 +309,8 @@ resource "aws_ecs_service" "lb" {
     container_port   = local.container_port
     target_group_arn = aws_lb_target_group.default[0].arn
   }
+
+  tags = merge({ "Name" = var.name }, var.tags)
 }
 
 # This resource is conditionally built when not using awsvpc network mode
@@ -347,6 +359,8 @@ resource "aws_ecs_service" "sd" {
       0,
     )
   }
+
+  tags = merge({ "Name" = var.name }, var.tags)
 }
 
 # This resource is conditionally built when not using awsvpc network
@@ -385,4 +399,6 @@ resource "aws_ecs_service" "default" {
   }
 
   platform_version = var.platform_version
+
+  tags = merge({ "Name" = var.name }, var.tags)
 }

--- a/sg.tf
+++ b/sg.tf
@@ -25,12 +25,8 @@ resource "aws_security_group" "default" {
   description = "security group for ${var.name} service"
   name        = var.name
   vpc_id      = data.aws_subnet.selected[0].vpc_id
-  tags = merge(
-    {
-      "Name" = var.name
-    },
-    var.tags,
-  )
+
+  tags = merge({ "Name" = var.name }, var.tags)
 }
 
 # Allow the containers to receive packets from the LB

--- a/target_group.tf
+++ b/target_group.tf
@@ -42,5 +42,6 @@ resource "aws_lb_target_group" "default" {
     }
   }
   target_type = local.network_mode == "awsvpc" ? "ip" : "instance"
-  tags        = var.tags
+
+  tags = merge({ "Name" = var.name }, var.tags)
 }

--- a/task.tf
+++ b/task.tf
@@ -64,6 +64,8 @@ resource "aws_ecs_task_definition" "fargate" {
   cpu                      = local.cpu
   memory                   = local.memory
   requires_compatibilities = ["FARGATE"]
+
+  tags = merge({ "Name" = var.name }, var.tags)
 }
 
 resource "aws_ecs_task_definition" "ec2" {
@@ -106,4 +108,6 @@ resource "aws_ecs_task_definition" "ec2" {
   }
 
   requires_compatibilities = ["EC2"]
+
+  tags = merge({ "Name" = var.name }, var.tags)
 }


### PR DESCRIPTION
AWS finally added support for tagging ECS components. The impetus to doing this work now is that we're not able to effectively track costs for the increasing number of ECS services being deployed.