### PR TITLE
Fix `registry_id` template variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -249,7 +249,7 @@ variable "task_definition" {
     template_variables = optional(object({
       docker_tag  = string
       region      = string
-      registry_id = number
+      registry_id = string
     }))
   })
   default = null


### PR DESCRIPTION
The `registry_id` template variable was erroneously declared as type "number" rather than type "string". For AWS account numbers with a leading zero, this caused breakage.