### PR TITLE
Enhance by adding arguments and fixing missing tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ that points to the load balancer. Requires that a `load_balancer` block is defin
 * `desired_count` - (Optional) The number of instances of the task
 definition to place and keep running. Defaults to 1.
 
+* `force_new_deployment` - (Optional) Enable forcing a new task deployment of the service. This can be used to update tasks to use a newer Docker image with same image/tag combination (e.g., `myimage:latest`), roll Fargate tasks onto a newer platform version, or immediately deploy `ordered_placement_strategy` and `placement_constraints` updates.
+
 * `health_check` -  (Optional) A [health check block](#health_check).
 Health check blocks are documented below.
 
@@ -182,6 +184,8 @@ supported for other network modes.
 * `placement_constraints` - (Optional) Rules taken into consideration during task placement. Not compatible with the FARGATE launch type. The [`placement_constraints`](#placement_constraints) block is defined below.
 
 * `platform_version` - (Optional) Platform version for FARGATE launch type. Not compatible with other launch types.
+
+* `propagate_tags` - (Optional) Whether to propagate the tags from the task definition or the service to the tasks. May contain values `NONE`, `SERVICE`, `TASK_DEFINITION`. The default is `TASK_DEFINITION`.
 
 * `service_discovery` - (Optional) A [service discovery](#service_discovery) block.
 This parameter is used to configure

--- a/listener_rule.tf
+++ b/listener_rule.tf
@@ -25,6 +25,8 @@ resource "aws_alb_listener_rule" "default" {
       values = [var.load_balancer.host_header]
     }
   }
+
+  tags = local.tags
 }
 
 resource "aws_alb_listener_rule" "set_priority" {
@@ -49,4 +51,6 @@ resource "aws_alb_listener_rule" "set_priority" {
       values = [var.load_balancer.host_header]
     }
   }
+
+  tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -92,6 +92,10 @@ moved {
 # to   = aws_ecs_service.default
 #}
 
+locals {
+  tags = merge({ Name = var.name }, var.tags)
+}
+
 resource "aws_ecs_service" "default" {
   name                               = var.name
   launch_type                        = var.launch_type
@@ -100,9 +104,12 @@ resource "aws_ecs_service" "default" {
   desired_count                      = var.desired_count
   deployment_maximum_percent         = var.deployment_maximum_percent
   deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
-  health_check_grace_period_seconds  = var.health_check_grace_period_seconds
-  platform_version                   = var.platform_version
-  tags                               = merge({ Name = var.name }, var.tags)
+  # enable_ecs_managed_tags            = true
+  force_new_deployment              = var.force_new_deployment
+  health_check_grace_period_seconds = var.health_check_grace_period_seconds
+  platform_version                  = var.platform_version
+  propagate_tags                    = var.propagate_tags
+  tags                              = local.tags
 
   dynamic "load_balancer" {
     for_each = toset(var.load_balancer != null ? [var.load_balancer] : [])

--- a/target_group.tf
+++ b/target_group.tf
@@ -13,7 +13,7 @@ resource "aws_lb_target_group" "default" {
   port                 = var.load_balancer.container_port
   protocol             = "HTTP" # The path between the LB and containers is trusted.
   target_type          = var.task_definition.network_mode == "awsvpc" ? "ip" : "instance"
-  tags                 = merge({ Name = var.name }, var.tags)
+  tags                 = local.tags
   vpc_id               = one(data.aws_lb.selected.*.vpc_id)
 
   # TODO: It wouild be really nice if Terraform would "short-circuit" and

--- a/task.tf
+++ b/task.tf
@@ -81,5 +81,5 @@ resource "aws_ecs_task_definition" "default" {
   memory                   = var.task_definition.memory
   requires_compatibilities = var.launch_type == "FARGATE" ? ["FARGATE"] : ["EC2"]
 
-  tags = merge({ Name = var.name }, var.tags)
+  tags = local.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -76,6 +76,12 @@ variable "desired_count" {
   default     = 1
 }
 
+variable "force_new_deployment" {
+  description = "Enable forcing a new task deployment of the service"
+  type        = bool
+  default     = false
+}
+
 variable "health_check" {
   description = "Health check block"
   type = object({
@@ -198,6 +204,17 @@ variable "platform_version" {
   default     = null
 }
 
+variable "propagate_tags" {
+  description = "Whether to propagate the tags from the task definition or the service to the tasks"
+  type        = string
+  default     = "TASK_DEFINITION"
+
+  validation {
+    condition     = try(contains(["NONE", "SERVICE", "TASK_DEFINITION"], var.propagate_tags), true)
+    error_message = "The 'propagate_tags' value is not one of the valid values 'NONE', 'SERVICE', or 'TASK_DEFINITION'."
+  }
+}
+
 variable "service_discovery" {
   description = "Service discovery block"
   type = object({
@@ -219,8 +236,10 @@ variable "service_discovery" {
   default = null
 }
 
-# FIXME: Confirm whether the below is still true, and consider converting to object.
-# The `stickiness` argument MUST have a default; Terraform will fail if not defined.
+# FIXME: Confirm whether the below statement is still true, and
+# consider converting to object.
+# The `stickiness` argument MUST have a default; Terraform will fail
+# if not defined.
 variable "stickiness" {
 
   description = "If specified, the [`stickiness`](#stickiness) block causes the load balancer to bind client requests to the same target. Valid only with application load balancers. Not valid without an application load balancer."


### PR DESCRIPTION
*   Add `propagate_tags` string argument. The default value is `TASK_DEFINITION`, and instead may be `NONE` or `SERVICE`. This omission caused the creation of tasks without tags.
    
*   Add tags to listener_rule now that they're supported.
    
 *   Add `force_new_deployment` Boolean argument.