### PR TITLE
Refactor to allow separate cooldown periods

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,6 @@ An `autoscale` block is a nested data structure that defines whether the contain
     metrics = {
       CPUUtilization = {
         adjustment_type         = "ChangeInCapacity"
-        cooldown                = 60
         datapoints_to_alarm     = 1
         evaluation_periods      = 1
         metric_aggregation_type = "Average"
@@ -243,6 +242,7 @@ An `autoscale` block is a nested data structure that defines whether the contain
 
         down = {
           comparison_operator         = "LessThanThreshold"
+          cooldown                    = 180
           metric_interval_upper_bound = 0
           scaling_adjustment          = -1
           threshold                   = 40
@@ -250,6 +250,7 @@ An `autoscale` block is a nested data structure that defines whether the contain
 
         up = {
           comparison_operator         = "GreaterThanOrEqualToThreshold"
+          cooldown                    = 60
           metric_interval_lower_bound = 1
           scaling_adjustment          = 1
           threshold                   = 70
@@ -276,8 +277,6 @@ Each autoscaling `metrics` sub-object allows specifying the following arguments:
 
 * `adjustment_type` - (Required) Whether the adjustment is an absolute number or a percentage of the current capacity.
 
-* `cooldown` - (Required) Amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start.
-
 * `datapoints_to_alarm` -  - (Optional) The number of datapoints that must be breaching the threshold to trigger the alarm.
 
 * `evaluation_periods` - (Required) The number of periods over which data is compared to the specified threshold.
@@ -298,6 +297,8 @@ Each autoscaling `metrics` sub-object allows specifying the following arguments:
 The `autoscale.metrics.down` and `autoscale.metrics.up` sub-objects use the same input variables, albeit for scaling down and scaling up, respectively.
 
 * `comparison_operator` - (Required) The arithmetic operation to use when comparing the statistic and threshold.
+
+* `cooldown` - (Optional) Amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start.
 
 * `metric_interval_lower_bound` - (Optional) Lower bound for the difference between the alarm threshold and the CloudWatch metric. Without a value, AWS will treat this bound as negative infinity.
 

--- a/autoscale.tf
+++ b/autoscale.tf
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "down" {
   namespace           = "AWS/ECS"
   period              = each.value.period
   statistic           = each.value.statistic
-  tags                = merge({ Name = var.name }, var.tags)
+  tags                = local.tags
   threshold           = each.value.down.threshold
 
   dimensions = {
@@ -58,7 +58,7 @@ resource "aws_cloudwatch_metric_alarm" "up" {
   namespace           = "AWS/ECS"
   period              = each.value.period
   statistic           = each.value.statistic
-  tags                = merge({ Name = var.name }, var.tags)
+  tags                = local.tags
   threshold           = each.value.up.threshold
 
   dimensions = {
@@ -79,7 +79,7 @@ resource "aws_appautoscaling_policy" "down" {
 
   step_scaling_policy_configuration {
     adjustment_type         = each.value.adjustment_type
-    cooldown                = each.value.cooldown
+    cooldown                = each.value.down.cooldown
     metric_aggregation_type = each.value.metric_aggregation_type
 
     step_adjustment {
@@ -102,7 +102,7 @@ resource "aws_appautoscaling_policy" "up" {
 
   step_scaling_policy_configuration {
     adjustment_type         = each.value.adjustment_type
-    cooldown                = each.value.cooldown
+    cooldown                = each.value.up.cooldown
     metric_aggregation_type = each.value.metric_aggregation_type
 
     step_adjustment {

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,6 @@ variable "autoscale" {
       object({
         actions_enabled         = optional(bool, true)
         adjustment_type         = string
-        cooldown                = optional(number, null)
         datapoints_to_alarm     = optional(number, null)
         evaluation_periods      = number
         metric_aggregation_type = string
@@ -32,6 +31,7 @@ variable "autoscale" {
         # TODO: Validate that either lower or upper bound are non-null.
         down = object({
           comparison_operator         = string
+          cooldown                    = optional(number, null)
           metric_interval_lower_bound = optional(number, null)
           metric_interval_upper_bound = optional(number, null)
           scaling_adjustment          = number
@@ -40,6 +40,7 @@ variable "autoscale" {
         # TODO: Validate that either lower or upper bound are non-null.
         up = object({
           comparison_operator         = string
+          cooldown                    = optional(number, null)
           metric_interval_lower_bound = optional(number, null)
           metric_interval_upper_bound = optional(number, null)
           scaling_adjustment          = number


### PR DESCRIPTION
Scale-up and scale-down autoscaling policies used the same value for cooldown. Move this into the "down" and "up" blocks to allow separate values for each scaling policy.