### PR TITLE
Update terraform-aws-util module to latest version

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,6 +4,9 @@ name: terraform
 
 on:
   push:
+#   branches:
+#     - master
+  pull_request:
 
 jobs:
   terraform:
@@ -17,7 +20,10 @@ jobs:
 
       - name: terraform setup
         uses: hashicorp/setup-terraform@v3
+      #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
       - name: run make
+      # env:
+      #   TOKEN: ${{ secrets.TOKEN }}
         run: |
           make all

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: tfc test
 tfc: .terraform
 	@# Basic Terraform validation and formating checks
 	terraform version
-	AWS_DEFAULT_REGION=us-east-2 terraform validate
+	terraform validate
 	terraform fmt -check
 
 # Create .terraform if does not exist
@@ -28,7 +28,8 @@ test:
 	# Do NOT put terraform-aws in the title of the top-level README
 	! grep "#\s*terraform-aws-" README.md
 	# Do NOT use type string when you can use type number or bool!
-	! $(EGREP) '"\d+"|"true"|"false"' $(SRCS) $(DOCS)
+#	! $(EGREP) '"\d+"|"true"|"false"' $(SRCS) $(DOCS)
+	! $(EGREP) '"\d+"|"true"|"false"' $(SRCS)
 	# Do NOT use old style maps in docs
 	! $(EGREP) "\w+\s*\{" $(DOCS)
 	# Do NOT drop the "s" in outputs.tf or variables.tf!

--- a/data.tf
+++ b/data.tf
@@ -17,7 +17,7 @@ locals {
 # Look up matching subnets.
 
 module "get-subnets" {
-  source = "github.com/techservicesillinois/terraform-aws-util//modules/get-subnets?ref=v3.0.4"
+  source = "github.com/techservicesillinois/terraform-aws-util//modules/get-subnets?ref=v3.0.5"
 
   count       = local.do_subnet_lookup ? 1 : 0
   subnet_type = var.network_configuration.subnet_type


### PR DESCRIPTION
The legacy 'tier' variable in the terraform-aws-util module has been retired. Accordingly, bump this module to refer to latest version of terraform-aws-util.